### PR TITLE
fix: transformer path for rn-59.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,9 @@ var upstreamTransformer = null;
 var reactNativeVersionString = require("react-native/package.json").version;
 var reactNativeMinorVersion = semver(reactNativeVersionString).minor;
 
-if (reactNativeMinorVersion >= 56) {
+if (reactNativeMinorVersion >= 59) {
+  upstreamTransformer = require("metro-react-native-babel-transformer");
+} else if (reactNativeMinorVersion >= 56) {
   upstreamTransformer = require("metro/src/reactNativeTransformer");
 } else if (reactNativeMinorVersion >= 52) {
   upstreamTransformer = require("metro/src/transformer");


### PR DESCRIPTION
For rn version 59.0 & above the transformer path has been changed. This PR adds proper transformer path for version 59 & above.